### PR TITLE
chore: vscode tsdk

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,5 @@
   "[javascript]": { "editor.formatOnSave": true },
   "[typescript]": { "editor.formatOnSave": true },
   "[typescriptreact]": { "editor.formatOnSave": true },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
assim o vscode consegue identificar corretamente a versão que estamos usando do typescript e não emite erros falsos-positivos